### PR TITLE
Fix: Markdown-it has a typographer option, not typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 var md = require('markdown-it')({
   html: true,
   linkify: true,
-  typography: true
+  typographer: true
 }).use(require('markdown-it-imsize')); // <-- this use(package_name) is required
 ```
 


### PR DESCRIPTION
See here: https://github.com/markdown-it/markdown-it/blob/46bd681eadb2cf19e26ecdbf200d5d083ac2b8d4/bin/markdown-it.js#L91